### PR TITLE
Fix small typo in hashbang line of example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ That's it.
 
 All your git hooks will have the same contents - only the target folder name will (maybe) differ.
 
-	#!/usr/bin/evn php
+	#!/usr/bin/env php
 	<?php
 
 	include 'vendor/wcm/git-php-hooks/GitPHPHooks.php';


### PR DESCRIPTION
`evn` --> `env`
